### PR TITLE
Fix OSX for Swiftup

### DIFF
--- a/Sources/Spawn/Spawn.swift
+++ b/Sources/Spawn/Spawn.swift
@@ -64,7 +64,7 @@ public final class Spawn {
     var threadInfo: ThreadInfo!
 
     func watchStreams() {
-        #if(OSX)
+        #if os(OSX)
         func callback(x: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
             let threadInfo = unsafeBitCast(x, to: UnsafeMutablePointer<ThreadInfo>.self).pointee
             let outputPipe = threadInfo.outputPipe
@@ -113,7 +113,7 @@ public final class Spawn {
     deinit {
         var status: Int32 = 0
 
-        #if(OSX)
+        #if os(OSX)
         if let tid = tid {
             pthread_join(tid, nil)
         }


### PR DESCRIPTION
# Purpose
I'm trying to bring Swiftup to OSX, and this is one of the dep that didn't work on OSX.

# Changes
use `if os(OSX)`